### PR TITLE
Fix of mongo cursor error.

### DIFF
--- a/selinonlib/storages/mongo.py
+++ b/selinonlib/storages/mongo.py
@@ -54,7 +54,7 @@ class MongoStorage(DataStorage):
         filtering = {'_id': 0}
         cursor = self.collection.find({'task_id': task_id}, filtering)
 
-        if len(cursor) > 1:
+        if cursor.count() > 1:
             raise ValueError("Multiple records with same task_id found")
         elif not cursor:
             raise FileNotFoundError("Record not found in database")


### PR DESCRIPTION
calling `len(cursor)` throws Error: object of type 'Cursor' has no len(). Proper call is cursor.count().
